### PR TITLE
🐛 Fix for log statements not going to next line

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -257,7 +257,7 @@ func (l *Logger) Fatal(message ...interface{}) {
 
 func (l *Logger) printLog(label string, message []interface{}) {
 	if logLevels[label] >= l.level {
-		fmt.Fprintf(l.logWriter, l.composeLog(label, message))
+		fmt.Fprintln(l.logWriter, l.composeLog(label, message))
 	}
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR -->
<!-- the icon will be either 💥 (major or breaking changes), ✨ (feature additions), 🐛 (patch and bugfixes), 📖 (documentation or proposals), or 🛠️ (other things) -->

**What this PR does / why we need it**:
Every log line that is outputted doesn't add a new line statement at the end of it. This PR attempts ti fix the issue of adding a newline character after every log line output.

**Which issue(s) this PR fixes**  <!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->
Fixes #27 
