### PR TITLE
fix error logging 🐛 

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -311,16 +311,16 @@ func (l *Logger) composeMessage(message []interface{}) interface{} {
 func (l *Logger) adaptMessage(message interface{}) interface{} {
 	switch message.(type) {
 	case string:
-		strMsg := message.(string)
 		if l.obscureSensitiveData && len(l.sensitiveParams) != 0 {
-			return strToObj(obscureParams(strMsg, l.sensitiveParams))
+			return strToObj(obscureParams(message.(string), l.sensitiveParams))
 		}
-		return strToObj(strMsg)
+		return strToObj(message.(string))
+	case error:
+		return message.(error).Error()
 	default:
 		if l.obscureSensitiveData && len(l.sensitiveParams) != 0 {
 			jsn, _ := json.Marshal(message)
-			strMsg := obscureParams(string(jsn), l.sensitiveParams)
-			return strToObj(strMsg)
+			return strToObj(obscureParams(string(jsn), l.sensitiveParams))
 		}
 	}
 	return message

--- a/logger_test.go
+++ b/logger_test.go
@@ -454,6 +454,7 @@ func TestAdaptMessage(t *testing.T) {
 		struct{ test string }{"Hello test"}:  "{Hello test}",
 		"Hi message":                         "Hi message",
 		`{"name": "John", "surname": "Doe"}`: `map[name:John surname:Doe]`,
+		fmt.Errorf("Nice error!"):            "Nice error!",
 	}
 
 	var b bytes.Buffer


### PR DESCRIPTION
**What this PR does / why we need it**:
log.Error(err) was not returning the error message in the `message` field

**Which issue(s) this PR fixes** 
Issue has not been tracked
